### PR TITLE
Upgrade de la syntaxe de déclaration des routes

### DIFF
--- a/src/Resources/config/routes/admin.yaml
+++ b/src/Resources/config/routes/admin.yaml
@@ -18,7 +18,7 @@ monsieurbiz_menu_admin_menu_item_create_for_menu:
     path: /menus/{menuId}/new-item
     methods: [GET, POST]
     defaults:
-        _controller: monsieurbiz_menu.controller.menu_item:createAction
+        _controller: monsieurbiz_menu.controller.menu_item::createAction
         _sylius:
             section: admin
             permission: true
@@ -47,7 +47,7 @@ monsieurbiz_menu_admin_menu_item_create_for_parent:
     path: /menus/{menuId}/item/{parentId}/new-item
     methods: [GET, POST]
     defaults:
-        _controller: monsieurbiz_menu.controller.menu_item:createAction
+        _controller: monsieurbiz_menu.controller.menu_item::createAction
         _sylius:
             section: admin
             permission: true
@@ -69,7 +69,7 @@ monsieurbiz_menu_admin_menu_item_update:
     path: /menus/{menuId}/update-item/{id}
     methods: [GET, PUT, POST]
     defaults:
-        _controller: monsieurbiz_menu.controller.menu_item:updateAction
+        _controller: monsieurbiz_menu.controller.menu_item::updateAction
         _sylius:
             section: admin
             permission: true
@@ -88,7 +88,7 @@ monsieurbiz_menu_admin_menu_item_delete:
     path: /menus/{menuId}/delete-item/{id}
     methods: [DELETE]
     defaults:
-        _controller: monsieurbiz_menu.controller.menu_item:deleteAction
+        _controller: monsieurbiz_menu.controller.menu_item::deleteAction
         _sylius:
             section: admin
             permission: true
@@ -98,7 +98,7 @@ monsieurbiz_menu_admin_menu_item_move_up:
     path: /menus/{menuId}/move-item/{id}/up
     methods: [PUT]
     defaults:
-        _controller: monsieurbiz_menu.controller.menu_item:moveUpAction
+        _controller: monsieurbiz_menu.controller.menu_item::moveUpAction
         _sylius: &move_sylius
             section: admin
             permission: true
@@ -108,5 +108,5 @@ monsieurbiz_menu_admin_menu_item_move_down:
     path: /menus/{menuId}/move-item/{id}/down
     methods: [PUT]
     defaults:
-        _controller: monsieurbiz_menu.controller.menu_item:moveDownAction
+        _controller: monsieurbiz_menu.controller.menu_item::moveDownAction
         _sylius: *move_sylius


### PR DESCRIPTION
Symfony 6 a supprimé le support de routes avec `:` entre le nom de la classe du controlleur et la méthode. Nous devons exclusivement utiliser `::`.